### PR TITLE
remove dbdisconnect() calls from functions

### DIFF
--- a/R/dbpf_devices.R
+++ b/R/dbpf_devices.R
@@ -20,10 +20,11 @@
 # =============================================================================
 
 dbpf_devices <- function(con) {
-	con <- dbpf_con() # get connection
+  if (missing(con)){
+	  con <- dbpf_con() # get connection
+  }
 	query <- paste("SELECT * FROM devices")
 	devices <- dbGetQuery(con, query)
 	devices <- subset(devices, select=-id)
-	dbDisconnect(con) # close connection
 	return(devices)
 }

--- a/R/dbpf_fields.R
+++ b/R/dbpf_fields.R
@@ -34,6 +34,5 @@ dbpf_fields <- function(con, tables = "") {
 	for (t in 1:length(tables)) {
 		fields <- rbind(fields, dbGetFields(con,tables[t]))
 	}
-	dbDisconnect(con) # close connection
 	return(fields)
 }

--- a/R/dbpf_inventory.R
+++ b/R/dbpf_inventory.R
@@ -32,7 +32,6 @@ dbpf_inventory <- function(con, type="observations_by_locations") {
 		                 "FROM locations INNER JOIN observations ON ",
 		                 "locations.coordinates = observations.location ",
 		                 "ORDER BY locations.name ASC;"))
-		dbDisconnect(con)
 		return(res)
 	}
 	

--- a/R/dbpf_locations.R
+++ b/R/dbpf_locations.R
@@ -40,6 +40,5 @@ dbpf_locations <- function(con, type='point') {
 	} 	
 	
 	locations <- dbGetQuery(con, query)
-	dbDisconnect(con) # close connection
 	return(locations)
 }

--- a/R/dbpf_locations_in_plot.R
+++ b/R/dbpf_locations_in_plot.R
@@ -28,11 +28,9 @@ dbpf_locations_in_plot <- function(con, locname) {
   query <- paste0("SELECT ST_AsText(coordinates) as coordinates ",
                  "FROM locations WHERE name ='",locname,"'")
   locations <- dbGetQuery(con, query)
-  #dbDisconnect(con) # close connection
-  
   
   query <- paste0("SELECT * FROM locations WHERE ST_Within(locations.coordinates, ST_SetSRID(ST_GeomFromText('",locations,"'),4326))")
   loggers <- dbGetQuery(con, query)
-  dbDisconnect(con) # close connection
+  
   return(loggers)
 }

--- a/R/dbpf_observations_plot.R
+++ b/R/dbpf_observations_plot.R
@@ -89,8 +89,7 @@ dbpf_observations_plot <- function(con, location_name, unit_of_measurement = "C"
     		}  
     	}           	
     }                            	
- 	#dbDisconnect(con)
-	
+
     #make time series
  	qxts <- xts(series, order.by = time$time)
 

--- a/R/dbpf_sensors.R
+++ b/R/dbpf_sensors.R
@@ -32,6 +32,5 @@ dbpf_sensors <- function(con, manual=TRUE) {
 	}
 	
 	sensors <- dbGetQuery(con, query)
-	dbDisconnect(con)
 	return(sensors)
 }

--- a/R/dbpf_table_columns.R
+++ b/R/dbpf_table_columns.R
@@ -35,7 +35,7 @@ dbpf_table_columns <- function(con, tablename, detailed=F){
                    WHERE table_name ='%s'
                    AND table_schema = 'public'", tablename)
   result <- dbGetQuery(con, query)
-  dbDisconnect(con)
+
   if (!detailed){
     result <- result$column_name
   }

--- a/R/dbpf_tables.R
+++ b/R/dbpf_tables.R
@@ -23,6 +23,6 @@ dbpf_tables <- function(con) {
 	}
   
 	tables <- dbListTables(con)
-	dbDisconnect(con) # close connection
+
 	return(tables)
 }	

--- a/R/dbpf_trumpet_curve.R
+++ b/R/dbpf_trumpet_curve.R
@@ -97,8 +97,6 @@ dbpf_trumpet_curve <- function(con, borehole_name, gst_names="", air_names="",
 	            "Range:", round(rnge,2),
 	            "SurfO:", round(mean-MAAT,2)))
 		
-	# clean up
-	dbDisconnect(con)	
 }
 
 


### PR DESCRIPTION
some functions had calls to `dbdisconnect()` which closes the `con` connection to the database.  This can be annoying, and it usually makes more sense to close the connection after you're done.

closes #8